### PR TITLE
Adding workflow ID and step code to appform directive.

### DIFF
--- a/lib/initialisation/index.js
+++ b/lib/initialisation/index.js
@@ -25,4 +25,9 @@ angular.module(CONSTANTS.WORKFLOW_DIRECTIVE_MODULE).run(function($state, workflo
       workorderId: workorder.id
     });
   });
+})
+.filter('isEmpty', function() {
+  return function(object) {
+    return (Object.keys(object).length === 0);
+  };
 });

--- a/lib/workflow-process/workflow-process-steps/workflow-process-steps-directive.js
+++ b/lib/workflow-process/workflow-process-steps/workflow-process-steps-directive.js
@@ -9,7 +9,7 @@ angular.module(CONSTANTS.WORKFLOW_DIRECTIVE_MODULE).directive('workflowStep', fu
       }), function(currentStep) {
         if (currentStep) {
           if (currentStep.formId) {
-            element.html('<appform form-id="step.formId"></appform>');
+            element.html('<appform step-code="ctrl.stepCurrent.code" workorder-id="ctrl.workorder.id" form-id="ctrl.stepCurrent.formId"></appform>');
             $compile(element.contents())(scope);
           } else if (currentStep.templatePath) {
             $templateRequest(currentStep.templatePath).then(function(template) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workflow-angular",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "An Angular 1 Implementation of the fh-wfm-workflow module",
   "main": "lib/workflow-ng.js",
   "repository": {


### PR DESCRIPTION
# Motivation

It would be useful for the `appform` step to have information on what workorder and step code it is being instantiated.

This allows for easier step completion when the step requires asynchronous operations to complete. In the case of appforms, the step requires that the submission be uploaded to a remote store.