### PR TITLE
Fix progress numbering

### DIFF
--- a/dist/workflow-process-begin.tpl.html.js
+++ b/dist/workflow-process-begin.tpl.html.js
@@ -8,7 +8,7 @@ try {
 ngModule.run(['$templateCache', function ($templateCache) {
   $templateCache.put('wfm-template/workflow-process-begin.tpl.html',
     '<div class="workflow" ng-if="ctrl.workflow">\n' +
-    '  <workflow-progress workflow="ctrl.workflow" step-index="ctrl.stepIndex"></workflow-progress>\n' +
+    '  <workflow-progress workflow="ctrl.workflow" step-index="-1"></workflow-progress>\n' +
     '\n' +
     '  <workorder workorder="ctrl.workorder" status="ctrl.status"></workorder>\n' +
     '  <div class="workflow-actions md-padding md-whiteframe-z4">\n' +

--- a/dist/workflow-process-complete.tpl.html.js
+++ b/dist/workflow-process-complete.tpl.html.js
@@ -8,7 +8,7 @@ try {
 ngModule.run(['$templateCache', function ($templateCache) {
   $templateCache.put('wfm-template/workflow-process-complete.tpl.html',
     '<div class="workflow" ng-if="ctrl.workflow">\n' +
-    '  <workflow-progress workflow="ctrl.workflow" step-index="Object.keys(ctrl.workflow.steps).length + 3"></workflow-progress>\n' +
+    '  <workflow-progress workflow="ctrl.workflow" step-index="ctrl.stepIndex"></workflow-progress>\n' +
     '\n' +
     '  <workorder workorder="ctrl.workorder" status="ctrl.result.status"></workorder>\n' +
     '  <workflow-result result="ctrl.result" workflow="ctrl.workflow"></workflow-result>\n' +

--- a/lib/template/workflow-process-begin.tpl.html
+++ b/lib/template/workflow-process-begin.tpl.html
@@ -1,5 +1,5 @@
 <div class="workflow" ng-if="ctrl.workflow">
-  <workflow-progress workflow="ctrl.workflow" step-index="ctrl.stepIndex"></workflow-progress>
+  <workflow-progress workflow="ctrl.workflow" step-index="-1"></workflow-progress>
 
   <workorder workorder="ctrl.workorder" status="ctrl.status"></workorder>
   <div class="workflow-actions md-padding md-whiteframe-z4">

--- a/lib/template/workflow-process-complete.tpl.html
+++ b/lib/template/workflow-process-complete.tpl.html
@@ -1,5 +1,5 @@
 <div class="workflow" ng-if="ctrl.workflow">
-  <workflow-progress workflow="ctrl.workflow" step-index="Object.keys(ctrl.workflow.steps).length + 3"></workflow-progress>
+  <workflow-progress workflow="ctrl.workflow" step-index="ctrl.stepIndex"></workflow-progress>
 
   <workorder workorder="ctrl.workorder" status="ctrl.result.status"></workorder>
   <workflow-result result="ctrl.result" workflow="ctrl.workflow"></workflow-result>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workflow-angular",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "An Angular 1 Implementation of the fh-wfm-workflow module",
   "main": "lib/workflow-ng.js",
   "repository": {


### PR DESCRIPTION
# Change

This change fixes a bug when the begin screen was on the first step in the progress bar.

The summary bar was adding 3 to the step index. It should be based on just the current step index.