### PR TITLE
[RAINCATCH-797] remove view summary button in workorder summary

### DIFF
--- a/dist/workflow-process-begin.tpl.html.js
+++ b/dist/workflow-process-begin.tpl.html.js
@@ -11,13 +11,13 @@ ngModule.run(['$templateCache', function ($templateCache) {
     '  <workflow-progress workflow="ctrl.workflow" step-index="-1"></workflow-progress>\n' +
     '\n' +
     '  <workorder workorder="ctrl.workorder" status="ctrl.status"></workorder>\n' +
-    '  <div class="workflow-actions md-padding md-whiteframe-z4">\n' +
+    '  <div ng-if="ctrl.notCompleted" class="workflow-actions md-padding md-whiteframe-z4">\n' +
     '    <md-button ng-click="ctrl.begin()" class="md-primary">\n' +
     '      <span ng-if="ctrl.stepIndex === 0">Begin Workflow</span>\n' +
     '      <span ng-if="ctrl.stepIndex > 0 && ctrl.stepIndex < ctrl.workflow.steps.length">Continue Workflow</span>\n' +
-    '      <span ng-if="ctrl.stepIndex >= ctrl.workflow.steps.length">View Summary</span>\n' +
     '    </md-button>\n' +
     '  </div>\n' +
+    '  <workflow-result ng-if="ctrl.result" result="ctrl.result" workflow="ctrl.workflow"></workflow-result>\n' +
     '</div>\n' +
     '');
 }]);

--- a/lib/template/workflow-process-begin.tpl.html
+++ b/lib/template/workflow-process-begin.tpl.html
@@ -2,11 +2,11 @@
   <workflow-progress workflow="ctrl.workflow" step-index="-1"></workflow-progress>
 
   <workorder workorder="ctrl.workorder" status="ctrl.status"></workorder>
-  <div class="workflow-actions md-padding md-whiteframe-z4">
+  <div ng-if="ctrl.notCompleted" class="workflow-actions md-padding md-whiteframe-z4">
     <md-button ng-click="ctrl.begin()" class="md-primary">
       <span ng-if="ctrl.stepIndex === 0">Begin Workflow</span>
       <span ng-if="ctrl.stepIndex > 0 && ctrl.stepIndex < ctrl.workflow.steps.length">Continue Workflow</span>
-      <span ng-if="ctrl.stepIndex >= ctrl.workflow.steps.length">View Summary</span>
     </md-button>
   </div>
+  <workflow-result ng-if="ctrl.result" result="ctrl.result" workflow="ctrl.workflow"></workflow-result>
 </div>

--- a/lib/workflow-process/workflow-process-begin/workflow-process-begin-controller.js
+++ b/lib/workflow-process/workflow-process-begin/workflow-process-begin-controller.js
@@ -24,6 +24,7 @@ function WorkflowProcessBeginController($state, workflowMediatorService, $stateP
       self.status = workflowSummaryDetails.status;
       self.stepIndex = workflowSummaryDetails.nextStepIndex;
       self.result = workflowSummaryDetails.result;
+      self.notCompleted = self.stepIndex < self.workflow.steps.length;
     });
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-wfm-workflow-angular",
-  "version": "0.2.2",
+  "version": "0.2.4",
   "description": "An Angular 1 Implementation of the fh-wfm-workflow module",
   "main": "lib/workflow-ng.js",
   "repository": {
@@ -19,7 +19,7 @@
   "author": "Brian Leathem",
   "license": "MIT",
   "dependencies": {
-    "fh-wfm-mediator": "0.3.3",
+    "fh-wfm-mediator": "0.3.4",
     "lodash": "4.7.0",
     "ng-feedhenry": "0.3.0",
     "q": "1.4.1",


### PR DESCRIPTION
# What
"View Summary" button is displayed in the workorder summary which opens the same page. This operation breaks the app and should be disabled when on the summary screen.

# How

- Remove "View Summary" button when on the summary screen.
- Display the workorder result (if result for the workorder exists) on the summary page without having to click on the view summary button. 
- Bump mediator to latest version

# JIRA Ticket
https://issues.jboss.org/browse/RAINCATCH-797